### PR TITLE
Fix onMouseDown event propagation where antd Select component is used

### DIFF
--- a/src/components/CustomSelect.tsx
+++ b/src/components/CustomSelect.tsx
@@ -1,5 +1,5 @@
 import Select from 'antd/lib/select'
-import React, { useCallback, useMemo, useRef } from 'react'
+import React, { MouseEvent, useCallback, useMemo, useRef } from 'react'
 
 import { formatValue, parsePartArray, partToString } from '../converter'
 import { DEFAULT_LOCALE_EN } from '../locale'
@@ -25,6 +25,8 @@ export default function CustomSelect(props: CustomSelectProps) {
     mode,
     ...otherProps
   } = props
+
+  const { onMouseDown, ...selectProps } = otherProps;
 
   const stringValue = useMemo(() => {
     if (value && Array.isArray(value)) {
@@ -85,9 +87,8 @@ export default function CustomSelect(props: CustomSelectProps) {
       return (
         <div>
           {testEveryValue[1]
-            ? `${locale.everyText || DEFAULT_LOCALE_EN.everyText} ${
-                testEveryValue[1]
-              }`
+            ? `${locale.everyText || DEFAULT_LOCALE_EN.everyText} ${testEveryValue[1]
+            }`
             : cronValue}
         </div>
       )
@@ -177,7 +178,7 @@ export default function CustomSelect(props: CustomSelectProps) {
             periodicityOnDoubleClick &&
             clicks.length > 1 &&
             clicks[clicks.length - 1].time - clicks[clicks.length - 2].time <
-              doubleClickTimeout
+            doubleClickTimeout
           ) {
             if (
               clicks[clicks.length - 1].value ===
@@ -211,6 +212,13 @@ export default function CustomSelect(props: CustomSelectProps) {
       setValue([])
     }
   }, [setValue, readOnly])
+
+  const onMouseDownCallback = useCallback((e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    if (onMouseDown) {
+      onMouseDown(e);
+    }
+  }, [onMouseDown])
 
   const internalClassName = useMemo(
     () =>
@@ -268,17 +276,18 @@ export default function CustomSelect(props: CustomSelectProps) {
       disabled={disabled}
       dropdownAlign={
         (unit.type === 'minutes' || unit.type === 'hours') &&
-        period !== 'day' &&
-        period !== 'hour'
+          period !== 'day' &&
+          period !== 'hour'
           ? {
-              // Usage: https://github.com/yiminghe/dom-align
-              // Set direction to left to prevent dropdown to overlap window
-              points: ['tr', 'br'],
-            }
+            // Usage: https://github.com/yiminghe/dom-align
+            // Set direction to left to prevent dropdown to overlap window
+            points: ['tr', 'br'],
+          }
           : undefined
       }
       data-testid={`custom-select-${unit.type}`}
-      {...otherProps}
+      onMouseDown={onMouseDownCallback}
+      {...selectProps}
     />
   )
 }

--- a/src/fields/Period.tsx
+++ b/src/fields/Period.tsx
@@ -1,5 +1,5 @@
 import Select, { BaseOptionType } from 'antd/lib/select'
-import React, { useCallback, useMemo } from 'react'
+import React, { MouseEvent, useCallback, useMemo } from 'react'
 
 import { DEFAULT_LOCALE_EN } from '../locale'
 import { PeriodProps, PeriodType } from '../types'
@@ -80,6 +80,10 @@ export default function Period(props: PeriodProps) {
     [setValue, readOnly]
   )
 
+  const onMouseDown = useCallback((e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  }, [])
+
   const internalClassName = useMemo(
     () =>
       classNames({
@@ -130,6 +134,7 @@ export default function Period(props: PeriodProps) {
         showArrow={!readOnly}
         open={readOnly ? false : undefined}
         data-testid='select-period'
+        onMouseDown={onMouseDown}
       />
     </div>
   )


### PR DESCRIPTION
<!--
Thank you for your contribution! 😄
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] README update
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
- Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution

If the `Cron` component is rendered inside of a component that has MouseEvent handlers, clicking on a dropdown item causes the ancestor component's MouseEvent handler to trigger. For ancestor's like modals, this behaviour is not desirable as it causes the modal to close (in most circumstances).

Handling this by explicitly stopping event propagation for the antd `Select` component.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Demo in storybook is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Tests are updated and passed without a decrease in coverage
- [x] Format (lint & prettier) script passed
- [x] Build script is working
- [x] README API section is updated or not needed
