### PR TITLE
Export parseCronString to allow third party use

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,39 @@ console.log('cron string:', converted)
 cron string: '1 2 * * *'
 ```
 
+The converter can also be helpful for parsing a string. Note that Sunday is represented as 0 in the output array but can be either 0 or 7 in the cron expression.
+
+```jsx
+import { converter } from 'react-js-cron'
+
+const [
+  minutes, 
+  hours, 
+  daysOfMonth, 
+  months, 
+  daysOfWeek
+] = converter.parseCronString('0 2,14 * * 1-5');
+
+console.log('parsed cron:', { 
+  minutes, 
+  hours, 
+  daysOfMonth, 
+  months, 
+  daysOfWeek
+})
+```
+
+```
+parsed cron: { 
+  minutes: [0], 
+  hours: [2, 14], 
+  daysOfMonth: [], 
+  months: [], 
+  daysOfWeek: [1, 2, 3, 4, 5]
+}
+```
+
+
 ## Examples
 
 Learn more with [dynamic settings](https://xrutayisire.github.io/react-js-cron/?path=/story/reactjs-cron--dynamic-settings).

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -303,7 +303,7 @@ function getPeriodFromCronParts(cronParts: number[][]): PeriodType {
 /**
  * Parses a cron string to an array of parts
  */
-function parseCronString(str: string) {
+export function parseCronString(str: string) {
   if (typeof str !== 'string') {
     throw new Error('Invalid cron string')
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 😄
-->

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] README update
- [X] Other (export existing code)

### 🔗 Related issue link

Simplifies [my pull request](https://github.com/garethgeorge/backrest/pull/741) to add a feature to [backrest](https://github.com/garethgeorge/backrest), a project that uses react-js-cron.

### 💡 Background and solution

The output of `parseCronString()` is useful for me but currently the only way to get it is through  `setValuesFromCronString()` which would be [very cumbersome](https://github.com/garethgeorge/backrest/pull/741#issuecomment-2811253184). 

This change simply exports the `parseCronString()` function with a note in the README. This will allow backrest to avoid an additional cron parsing dependency or the ugly `setValuesFromCronString()` code linked above.

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [X] Demo in storybook is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Tests are updated and passed without a decrease in coverage
- [X] Format (lint & prettier) script passed
- [X] Build script is working
- [X] README API section is updated or not needed