### PR TITLE
fix: don't error on clear button with default allowEmpty setting

### DIFF
--- a/src/Cron.tsx
+++ b/src/Cron.tsx
@@ -267,8 +267,7 @@ export default function Cron(props: CronProps) {
       // (manual dropdown changes) and in setValuesFromCronString (external
       // value changes).
       const hasEmptyError =
-        allowEmpty === 'never' &&
-        (clearButtonAction === 'empty' || isEmptyCron)
+        allowEmpty === 'never' && (clearButtonAction === 'empty' || isEmptyCron)
       const hasPerDropdownError =
         !hasEmptyError &&
         isEmptyCron &&

--- a/src/Cron.tsx
+++ b/src/Cron.tsx
@@ -259,10 +259,16 @@ export default function Cron(props: CronProps) {
 
       const isEmptyCron = newValue === '* * * * *'
       const isInitialValue = newValue === initialValueRef.current
+      // The 'for-default-value' check is intentionally NOT applied here.
+      // The clear button is an explicit user action to reset, not a value
+      // the user "arrived at" — applying 'for-default-value' would break
+      // the default behavior where clearing always succeeds.
+      // The 'for-default-value' check still applies in the useEffect
+      // (manual dropdown changes) and in setValuesFromCronString (external
+      // value changes).
       const hasEmptyError =
-        (allowEmpty === 'never' &&
-          (clearButtonAction === 'empty' || isEmptyCron)) ||
-        (allowEmpty === 'for-default-value' && isEmptyCron && !isInitialValue)
+        allowEmpty === 'never' &&
+        (clearButtonAction === 'empty' || isEmptyCron)
       const hasPerDropdownError =
         !hasEmptyError &&
         isEmptyCron &&

--- a/src/tests/Cron.updateValue.test.tsx
+++ b/src/tests/Cron.updateValue.test.tsx
@@ -336,7 +336,7 @@ describe('Cron update value test suite', () => {
     })
   })
 
-  it('should check that pressing clear with fill-with-every throws an error if allowEmpty is for-default-value', async () => {
+  it("should check that pressing clear with fill-with-every doesn't throw an error if allowEmpty is for-default-value", async () => {
     const user = userEvent.setup()
     const value = '1 1 1 1 1'
     const setValue = vi.fn()
@@ -356,15 +356,15 @@ describe('Cron update value test suite', () => {
       user.click(screen.getByText('Clear'))
     })
 
-    // Check that error is raised because * * * * * is empty and not the default value
+    // The clear button is an explicit reset action — it should not trigger
+    // a 'for-default-value' error even though * * * * * is treated as empty.
+    // The 'for-default-value' check only applies to manual dropdown changes
+    // and external value updates, not to the clear button.
     await waitFor(() => {
       expect(setValue).toHaveBeenNthCalledWith(2, '* * * * *', {
         selectedPeriod: 'year',
       })
-      expect(onError).toHaveBeenLastCalledWith({
-        description: 'Invalid cron expression',
-        type: 'invalid_cron',
-      })
+      expect(onError).toHaveBeenLastCalledWith(undefined)
     })
   })
 


### PR DESCRIPTION
## Summary

- Fixes a regression introduced in #89 (1b7ba7c) where clicking the Clear button with default settings (`allowEmpty = 'for-default-value'`, `clearButtonAction = 'fill-with-every'`) would show an error because `* * * * *` is now treated as empty
- The `for-default-value` check is removed from `handleClear` only — the clear button is an explicit user reset action, not a value the user "arrived at"
- All other `for-default-value` checks remain intact: useEffect (manual dropdown changes), `setValuesFromCronString` (external value changes), and converter (first render)

## What changed

| `clearButtonAction` | `allowEmpty` | Before #89 | After #89 (bug) | This PR |
|---|---|---|---|---|
| `fill-with-every` | `for-default-value` (default) | no error | **error** | **no error** (restored) |
| `fill-with-every` | `never` | no error | error | error (intentional) |
| `fill-with-every` | `always` | no error | no error | no error |
| `empty` | `never` | error | error | error |
| `empty` | `for-default-value` | no error | no error | no error |
| `empty` | `always` | no error | no error | no error |

## Test plan

- [x] All 96 existing tests pass (including all tests added in #89 for per-dropdown `allowEmpty` and external value changes)
- [x] One test assertion corrected: `for-default-value` + `fill-with-every` clear now asserts no error
- [x] Lint passes with 0 warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)