### PR TITLE
fix(ci): use Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,8 +31,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          registry-url: 'https://registry.npmjs.org'
+          node-version: 24
       - run: corepack enable
       - name: Install dependencies
         run: yarn --immutable


### PR DESCRIPTION
## Summary
- Switches publish job from Node 22 to Node 24
- Removes `registry-url` from `actions/setup-node`

## Why

npm trusted publishing (OIDC) requires **npm 11.5.1+** ([npm docs](https://docs.npmjs.com/trusted-publishers/)). Node 22 ships npm 10.9.x which can obtain the OIDC token for provenance signing but **cannot** do the OIDC-to-registry auth exchange — resulting in E404 on publish.

Node 24 ships npm 11.9.0 which fully supports OIDC publishing.

Additionally, `registry-url` in `setup-node` auto-sets `NODE_AUTH_TOKEN` to `GITHUB_TOKEN`, which makes npm use that invalid token instead of falling back to OIDC. Removing it lets npm default to the npm registry and use OIDC for auth.

## Checklist
- [x] Trusted publisher configured on npmjs.com (owner: `xrutayisire`, repo: `react-js-cron`, workflow: `release-please.yml`)
- [x] `id-token: write` permission set
- [x] `--provenance` flag on npm publish
- [x] `NODE_AUTH_TOKEN` NOT set (no interference with OIDC)
- [x] npm 11.9.0 via Node 24 (supports OIDC auth exchange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)